### PR TITLE
Allow multiple target destinations

### DIFF
--- a/src/App/Commands/Options/Parser.hs
+++ b/src/App/Commands/Options/Parser.hs
@@ -61,12 +61,12 @@ optsSyncToArchive = SyncToArchiveOptions
       <> showDefault <> value Oregon
       <> help "The AWS region in which to operate"
       )
-  <*> option (maybeReader (toLocation . Text.pack))
+  <*> many (option (maybeReader (toLocation . Text.pack))
       (   long "archive-uri"
       <>  help "Archive URI to sync to"
       <>  metavar "S3_URI"
-      <>  value (Local $ homeDirectory </> ".cabal" </> "archive")
-      )
+      -- <>  value (Local $ homeDirectory </> ".cabal" </> "archive")
+      ))
   <*> strOption
       (   long "store-path"
       <>  help "Path to cabal store"

--- a/src/App/Commands/Options/Types.hs
+++ b/src/App/Commands/Options/Types.hs
@@ -11,7 +11,7 @@ import qualified Antiope.Env as AWS
 
 data SyncToArchiveOptions = SyncToArchiveOptions
   { region        :: Region
-  , archiveUri    :: Location
+  , archiveUri    :: [Location]
   , storePath     :: FilePath
   , storePathHash :: Maybe String
   , threads       :: Int


### PR DESCRIPTION
Allow the user to sync to multiple locations.

```
$ cabal-cache sync-to-archive --archive-uri sdf --archive-uri qwe

Store path: /Users/david/.cabal/store
Store path hash: 01947a6a0f
Archive URI(s): sdf
Archive URI(s): qwe
Archive version: v2
Threads: 4
AWS Log level: Nothing
Syncing 130 packages
...
```