### PR TITLE
Move command parsers to command modules

### DIFF
--- a/src/App/Commands/Options/Parser.hs
+++ b/src/App/Commands/Options/Parser.hs
@@ -2,97 +2,11 @@
 
 module App.Commands.Options.Parser where
 
-import Antiope.Core                     (FromText, Region (..), fromText)
-import Antiope.Options.Applicative
-import App.Commands.Options.Types       (SyncFromArchiveOptions (..), SyncToArchiveOptions (..), VersionOptions (..))
-import App.Static                       (homeDirectory)
-import Control.Applicative
-import HaskellWorks.CabalCache.Location (Location (..), toLocation, (</>))
+import Antiope.Core               (FromText, fromText)
+import App.Commands.Options.Types (VersionOptions (..))
 import Options.Applicative
 
 import qualified Data.Text as Text
-
-optsSyncFromArchive :: Parser SyncFromArchiveOptions
-optsSyncFromArchive = SyncFromArchiveOptions
-  <$> option (auto <|> text)
-      (  long "region"
-      <> metavar "AWS_REGION"
-      <> showDefault <> value Oregon
-      <> help "The AWS region in which to operate"
-      )
-  <*> option (maybeReader (toLocation . Text.pack))
-      (   long "archive-uri"
-      <>  help "Archive URI to sync to"
-      <>  metavar "S3_URI"
-      <>  value (Local $ homeDirectory </> ".cabal" </> "archive")
-      )
-  <*> strOption
-      (   long "store-path"
-      <>  help "Path to cabal store"
-      <>  metavar "DIRECTORY"
-      <>  value (homeDirectory </> ".cabal" </> "store")
-      )
-  <*> optional
-      ( strOption
-        (   long "store-path-hash"
-        <>  help "Store path hash (do not use)"
-        <>  metavar "HASH"
-        )
-      )
-  <*> option auto
-      (   long "threads"
-      <>  help "Number of concurrent threads"
-      <>  metavar "NUM_THREADS"
-      <>  value 4
-      )
-  <*> optional
-      ( option autoText
-        (   long "aws-log-level"
-        <>  help "AWS Log Level.  One of (Error, Info, Debug, Trace)"
-        <>  metavar "AWS_LOG_LEVEL"
-        )
-      )
-
-optsSyncToArchive :: Parser SyncToArchiveOptions
-optsSyncToArchive = SyncToArchiveOptions
-  <$> option (auto <|> text)
-      (  long "region"
-      <> metavar "AWS_REGION"
-      <> showDefault <> value Oregon
-      <> help "The AWS region in which to operate"
-      )
-  <*> option (maybeReader (toLocation . Text.pack))
-      (   long "archive-uri"
-      <>  help "Archive URI to sync to"
-      <>  metavar "S3_URI"
-      <>  value (Local $ homeDirectory </> ".cabal" </> "archive")
-      )
-  <*> strOption
-      (   long "store-path"
-      <>  help "Path to cabal store"
-      <>  metavar "DIRECTORY"
-      <>  value (homeDirectory </> ".cabal" </> "store")
-      )
-  <*> optional
-      ( strOption
-        (   long "store-path-hash"
-        <>  help "Store path hash (do not use)"
-        <>  metavar "HASH"
-        )
-      )
-  <*> option auto
-      (   long "threads"
-      <>  help "Number of concurrent threads"
-      <>  metavar "NUM_THREADS"
-      <>  value 4
-      )
-  <*> optional
-      ( option autoText
-        (   long "aws-log-level"
-        <>  help "AWS Log Level.  One of (Error, Info, Debug, Trace)"
-        <>  metavar "AWS_LOG_LEVEL"
-        )
-      )
 
 optsVersion :: Parser VersionOptions
 optsVersion = pure VersionOptions


### PR DESCRIPTION
Keeping all command related code in the one module for maintainability.