### PR TITLE
Use same ghc-pkg version as specified by GHC version in plan.json

### DIFF
--- a/cabal-cache.cabal
+++ b/cabal-cache.cabal
@@ -110,12 +110,13 @@ library
       App.Commands.SyncToArchive
       App.Commands.Version
       App.Static
-      HaskellWorks.CabalCache.AWS.Env
       HaskellWorks.CabalCache.AppError
+      HaskellWorks.CabalCache.AWS.Env
       HaskellWorks.CabalCache.Concurrent.DownloadQueue
       HaskellWorks.CabalCache.Concurrent.Fork
       HaskellWorks.CabalCache.Concurrent.Type
       HaskellWorks.CabalCache.Core
+      HaskellWorks.CabalCache.Error
       HaskellWorks.CabalCache.GhcPkg
       HaskellWorks.CabalCache.Hash
       HaskellWorks.CabalCache.IO.Console

--- a/src/HaskellWorks/CabalCache/Error.hs
+++ b/src/HaskellWorks/CabalCache/Error.hs
@@ -1,0 +1,9 @@
+module HaskellWorks.CabalCache.Error
+  ( nothingToError
+  ) where
+
+import Control.Monad.Except
+
+nothingToError :: MonadError e m => e -> Maybe a -> m a
+nothingToError _ (Just a) = return a
+nothingToError e Nothing  = throwError e

--- a/src/HaskellWorks/CabalCache/Types.hs
+++ b/src/HaskellWorks/CabalCache/Types.hs
@@ -40,6 +40,10 @@ data Lib = Lib
   , exeDepends :: [Text]
   } deriving (Eq, Show, Generic)
 
+newtype CompilerContext = CompilerContext
+  { ghcPkgCmd :: [String]
+  } deriving (Show, Eq, Generic)
+
 instance FromJSON PlanJson where
   parseJSON = withObject "PlanJson" $ \v -> PlanJson
     <$> v .: "compiler-id"


### PR DESCRIPTION
Prevents the corruption described in #94