### PR TITLE
Implement Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ghc: ["8.8.4", "8.6.5"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
@@ -34,7 +34,7 @@ jobs:
                      -e 's/cabal_cache/cbc/g' \
                      cabal-cache.cabal
           sed -i.bak -e 's/Paths_cabal_cache/Paths_cbc/g' \
-                     src/**/*.hs exe/*.hs
+                     src/**/*.hs app/*.hs
 
       - name: Set some window specific things
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: Binaries
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  pull_request:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        ghc: ["8.8.4", "8.6.5"]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-haskell@v1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: "3.2"
+
+      - name: Shorten binary names
+        run: |
+          sed -i.bak -e 's/cabal-cache/cbc/g' \
+                     -e 's/cabal_cache/cbc/g' \
+                     cabal-cache.cabal
+          sed -i.bak -e 's/Paths_cabal_cache/Paths_cbc/g' \
+                     src/**/*.hs exe/*.hs
+
+      - name: Set some window specific things
+        if: matrix.os == 'windows-latest'
+        run: echo '::set-env name=EXE_EXT::.exe'
+
+      - name: Set some linux specific things
+        if: matrix.os == 'ubuntu-latest'
+        run: echo '::set-env name=LINUX_CABAL_ARGS::--enable-executable-static --ghc-options=-split-sections'
+
+      - name: Build
+        # Try building it twice in case of flakey builds on Windows
+        run: |
+          cabal build exe:cabal-cache -O2 --write-ghc-environment-files=ghc8.4.4+ $LINUX_CABAL_ARGS || \
+          cabal build exe:cabal-cache -O2 --write-ghc-environment-files=ghc8.4.4+ $LINUX_CABAL_ARGS -j1
+
+      - name: Compress Binary
+        id: compress_binary
+        env:
+          GHC_VER: ${{ matrix.ghc }}
+        run: |
+          HS_BIN=$(find dist-newstyle \( -name 'cabal-cache' -o -name 'cabal-cache.exe' \) -type f)
+          NAME=cabal-cache-$GHC_VER
+          mv $HS_BIN $NAME${{env.EXE_EXT}}
+          if [[ "$OSTYPE" == "msys" ]]; then
+            7z a $NAME.zip $NAME${{env.EXE_EXT}}
+            echo ::set-output name=path::$NAME.zip
+            echo ::set-output name=content_type::application/zip
+            echo ::set-output name=extension::zip
+          else
+            gzip --best $NAME
+            echo ::set-output name=path::$NAME.gz
+            echo ::set-output name=content_type::application/gzip
+            echo ::set-output name=extension::gz
+          fi
+
+      - name: Upload Release Binary
+        if: "github.event_name == 'release'"
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.compress_binary.outputs.path }}
+          asset_name: cabal-cache-${{ runner.OS }}-${{ matrix.ghc }}${{env.EXE_EXT}}.${{ steps.compress_binary.outputs.extension }}
+          asset_content_type: ${{ steps.compress_binary.outputs.content_type }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cabal-cache-${{ runner.OS }}-${{ matrix.ghc }}${{env.EXE_EXT}}.${{ steps.compress_binary.outputs.extension }}
+          path: ${{ steps.compress_binary.outputs.path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,12 @@ jobs:
       - uses: actions/cache@v2
         name: Cache cabal store
         with:
-          path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          key: cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal-cache.cabal') }}-${{ github.sha }}
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            dist-newstyle
+          key: cache-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal-cache.cabal') }}-${{ github.sha }}
           restore-keys: |
-            cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal-cache.cabal') }}-
+            cache-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal-cache.cabal') }}-
 
       - name: Shorten binary names
         run: |
@@ -65,10 +67,10 @@ jobs:
         env:
           GHC_VER: ${{ matrix.ghc }}
         run: |
-          HS_BIN=$(find dist-newstyle \( -name 'cbc' -o -name 'cbc.exe' \) -type f -executable)
+          HS_BIN=$(find dist-newstyle \( -name 'cbc' -o -name 'cbc.exe' \) -type f)
           test -f "$HS_BIN"
           NAME=cabal-cache-$GHC_VER
-          mv $HS_BIN $NAME${{env.EXE_EXT}}
+          cp $HS_BIN $NAME${{env.EXE_EXT}}
           if [[ "$OSTYPE" == "msys" ]]; then
             7z a $NAME.zip $NAME${{env.EXE_EXT}}
             echo ::set-output name=path::$NAME.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Build
         # Try building it twice in case of flakey builds on Windows
         run: |
-          cabal build exe:cabal-cache -O2 --write-ghc-environment-files=ghc8.4.4+ $LINUX_CABAL_ARGS || \
-          cabal build exe:cabal-cache -O2 --write-ghc-environment-files=ghc8.4.4+ $LINUX_CABAL_ARGS -j1
+          cabal build -O2 --write-ghc-environment-files=ghc8.4.4+ $LINUX_CABAL_ARGS || \
+          cabal build -O2 --write-ghc-environment-files=ghc8.4.4+ $LINUX_CABAL_ARGS -j1
 
       - name: Compress Binary
         id: compress_binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,11 @@ jobs:
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: "3.2"
 
       - uses: actions/cache@v2
         name: Cache cabal store
         with:
-          path: |
-            ${{ steps.setup-haskell.outputs.cabal-store }}
-            dist-newstyle
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
           key: cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal-cache.cabal') }}-${{ github.sha }}
           restore-keys: |
             cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal-cache.cabal') }}-
@@ -43,9 +40,11 @@ jobs:
         run: |
           sed -i.bak -e 's/cabal-cache/cbc/g' \
                      -e 's/cabal_cache/cbc/g' \
+                     -e 's/Paths_cabal_cache/Paths_cbc/g' \
                      cabal-cache.cabal
-          sed -i.bak -e 's/Paths_cabal_cache/Paths_cbc/g' \
-                     src/**/*.hs app/*.hs
+          find app src -name '*.hs' -type f \
+                    -exec sed -i.bak -e 's/Paths_cabal_cache/Paths_cbc/g' {} +
+          find app src -name '*.bak' -type f -exec rm {} +
 
       - name: Set some window specific things
         if: matrix.os == 'windows-latest'
@@ -66,7 +65,8 @@ jobs:
         env:
           GHC_VER: ${{ matrix.ghc }}
         run: |
-          HS_BIN=$(find dist-newstyle \( -name 'cabal-cache' -o -name 'cabal-cache.exe' \) -type f)
+          HS_BIN=$(find dist-newstyle \( -name 'cbc' -o -name 'cbc.exe' \) -type f -executable)
+          test -f "$HS_BIN"
           NAME=cabal-cache-$GHC_VER
           mv $HS_BIN $NAME${{env.EXE_EXT}}
           if [[ "$OSTYPE" == "msys" ]]; then
@@ -75,6 +75,7 @@ jobs:
             echo ::set-output name=content_type::application/zip
             echo ::set-output name=extension::zip
           else
+            strip $NAME
             gzip --best $NAME
             echo ::set-output name=path::$NAME.gz
             echo ::set-output name=content_type::application/gzip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,20 @@ jobs:
         with:
           submodules: true
       - uses: actions/setup-haskell@v1
+        id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: "3.2"
+
+      - uses: actions/cache@v2
+        name: Cache cabal store
+        with:
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            dist-newstyle
+          key: cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal-cache.cabal') }}-${{ github.sha }}
+          restore-keys: |
+            cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal-cache.cabal') }}-
 
       - name: Shorten binary names
         run: |


### PR DESCRIPTION
This builds and creates artifacts for linux, macos, windows. It also has a setup to upload binaries when releases are created. Most of the code is lifted from the haskell-language-server repo as they already figured out how to get around weird windows pathing issues with longer binary names.

The binary for linux is also built statically so it should work out of the box, even on more esoteric setups such as NixOS.

`secrets.GITHUB_TOKEN` comes baked into github actions and is not something you need to enable manually. (It just allows the action api access to its own repository in order to upload binaries to releases).

I wasn't sure if you wanted a binary for each GHC or not. If not, the binaries can be renamed to just be `cabal-cache
 
Fixes #129 