### PR TITLE
Fix slash handling on Windows

### DIFF
--- a/src/App/Commands/SyncFromArchive.hs
+++ b/src/App/Commands/SyncFromArchive.hs
@@ -15,10 +15,8 @@ import App.Commands.Options.Parser      (text)
 import App.Commands.Options.Types       (SyncFromArchiveOptions (SyncFromArchiveOptions))
 import Control.Applicative
 import Control.Lens                     hiding ((<.>))
-import Control.Monad                    (unless, void, when)
 import Control.Monad.Catch              (MonadCatch)
 import Control.Monad.Except
-import Control.Monad.IO.Class           (liftIO)
 import Data.ByteString.Lazy.Search      (replace)
 import Data.Generics.Product.Any        (the)
 import Data.Maybe

--- a/src/App/Commands/SyncToArchive.hs
+++ b/src/App/Commands/SyncToArchive.hs
@@ -16,7 +16,6 @@ import App.Commands.Options.Parser      (text)
 import App.Commands.Options.Types       (SyncToArchiveOptions (SyncToArchiveOptions))
 import Control.Applicative
 import Control.Lens                     hiding ((<.>))
-import Control.Monad                    (filterM, unless, when)
 import Control.Monad.Except
 import Control.Monad.Trans.Resource     (runResourceT)
 import Data.Generics.Product.Any        (the)

--- a/src/HaskellWorks/CabalCache/Core.hs
+++ b/src/HaskellWorks/CabalCache/Core.hs
@@ -19,7 +19,6 @@ module HaskellWorks.CabalCache.Core
 
 import Control.DeepSeq                  (NFData)
 import Control.Lens                     hiding ((<.>))
-import Control.Monad                    (forM)
 import Control.Monad.Catch
 import Control.Monad.Except
 import Data.Aeson                       (eitherDecode)

--- a/src/HaskellWorks/CabalCache/IO/Tar.hs
+++ b/src/HaskellWorks/CabalCache/IO/Tar.hs
@@ -13,7 +13,6 @@ module HaskellWorks.CabalCache.IO.Tar
 import Control.DeepSeq                  (NFData)
 import Control.Lens
 import Control.Monad.Except
-import Control.Monad.IO.Class           (MonadIO, liftIO)
 import Data.Generics.Product.Any
 import GHC.Generics
 import HaskellWorks.CabalCache.AppError


### PR DESCRIPTION
Improper slashes is causing `cabal-cache` not upload and download Windows cache files properly.