### PR TITLE
Handle all exceptions from download to ensure downloads are marked as failed

### DIFF
--- a/src/HaskellWorks/CabalCache/Concurrent/Fork.hs
+++ b/src/HaskellWorks/CabalCache/Concurrent/Fork.hs
@@ -1,17 +1,31 @@
+{-# LANGUAGE BlockArguments    #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module HaskellWorks.CabalCache.Concurrent.Fork where
 
-import Control.Exception (finally)
+import Control.Exception            (finally)
 import Control.Monad
+import HaskellWorks.CabalCache.Show (tshow)
 
-import qualified Control.Concurrent     as IO
-import qualified Control.Concurrent.STM as STM
+import qualified Control.Concurrent                 as IO
+import qualified Control.Concurrent.STM             as STM
+import qualified HaskellWorks.CabalCache.IO.Console as CIO
+import qualified System.IO                          as IO
 
 forkThreadsWait :: Int -> IO () -> IO ()
 forkThreadsWait n f = do
   tDone <- STM.atomically $ STM.newTVar (0 :: Int)
-  forM_ [1 .. n] $ \_ -> IO.forkIO $ do
-    f `finally` (STM.atomically $ STM.modifyTVar tDone (+1))
-
-  STM.atomically $ do
-    done <- STM.readTVar tDone
-    when (done < n) STM.retry
+  forM_ [1 .. n] $ \_ -> IO.forkFinally
+    do f `finally` STM.atomically (STM.modifyTVar tDone (+1))
+    \case
+      Left e -> do
+        CIO.hPutStrLn IO.stderr $ "Fatal exception occurred: " <> tshow e
+        CIO.hPutStrLn IO.stderr "Waiting for any remaining downlad threads to complete"
+        STM.atomically $ do
+          done <- STM.readTVar tDone
+          when (done < n) STM.retry
+      Right () -> do
+        STM.atomically $ do
+          done <- STM.readTVar tDone
+          when (done < n) STM.retry

--- a/src/HaskellWorks/CabalCache/Concurrent/Type.hs
+++ b/src/HaskellWorks/CabalCache/Concurrent/Type.hs
@@ -20,6 +20,6 @@ type ProviderId = PackageId
 
 data DownloadQueue = DownloadQueue
   { tDependencies :: STM.TVar (R.Relation ConsumerId ProviderId)
-  , tUploading    :: STM.TVar (S.Set PackageId)
+  , tDownloading  :: STM.TVar (S.Set PackageId)
   , tFailures     :: STM.TVar (S.Set PackageId)
   } deriving Generic


### PR DESCRIPTION
Handle all AWS exceptions by continuing and other exceptions by aborting.

Also some variables were named `uploading` and `tUploading` when they should say `downloading` and `tDownloading`.

These names used to be correct because once-up-a-time this was an upload queue, but for reasons*, it has been converted to a download queue, but this rename got missed.

* The reason being it's more fault-tolerant if `cabal-cache` tracks dependencies during download rather than upload because `cabal-cache` needs to keep the `cabal` store in a state where packages that are depended on exist.  The download queue ensures packages are downloaded in an order whereby if `cabal-cache` is interrupted at any time, what has already been downloaded to the cabal store is correct.