### PR TITLE
CHG: handle NotFound in readFirstAvailableResource to make sure that …

### DIFF
--- a/src/HaskellWorks/CabalCache/IO/Lazy.hs
+++ b/src/HaskellWorks/CabalCache/IO/Lazy.hs
@@ -105,6 +105,10 @@ readFirstAvailableResource :: ()
   -> ExceptT (OO.Variant e) m (LBS.ByteString, Location)
 readFirstAvailableResource envAws (a:|as) maxRetries = do
   (, a) <$> readResource envAws maxRetries a
+    & do OO.catch @NotFound \e -> do
+          case NEL.nonEmpty as of
+            Nothing -> OO.throwF (Identity e)
+            Just nas -> readFirstAvailableResource envAws nas maxRetries
     & do OO.catch @AwsError \e -> do
           case NEL.nonEmpty as of
             Nothing -> OO.throwF (Identity e)


### PR DESCRIPTION
Fixes [issue 236 ](https://github.com/haskell-works/cabal-cache/issues/236) in haskell-works/cabal-cache as described in the issue.